### PR TITLE
"order by" useless on updates

### DIFF
--- a/lib/template/Sortable.php
+++ b/lib/template/Sortable.php
@@ -181,8 +181,7 @@ class Doctrine_Template_Sortable extends Doctrine_Template
                               ->update(get_class($object))
                               ->set($this->_options['name'], $this->_options['name'] . ' + 1')
                               ->where($this->_options['name'] . ' < ?', $position)
-                              ->andWhere($this->_options['name'] . ' >= ?', $newPosition)
-                              ->orderBy($this->_options['name'] . ' DESC');
+                              ->andWhere($this->_options['name'] . ' >= ?', $newPosition);
 
       foreach ($this->_options['uniqueBy'] as $field)
       {
@@ -198,8 +197,7 @@ class Doctrine_Template_Sortable extends Doctrine_Template
                               ->update(get_class($object))
                               ->set($this->_options['name'], $this->_options['name'] . ' - 1')
                               ->where($this->_options['name'] . ' > ?', $position)
-                              ->andWhere($this->_options['name'] . ' <= ?', $newPosition)
-                              ->orderBy($this->_options['name'] . ' ASC');
+                              ->andWhere($this->_options['name'] . ' <= ?', $newPosition);
 
       foreach($this->_options['uniqueBy'] as $field)
       {


### PR DESCRIPTION
Hello,

Please excuse me if my english sucks, I'm french. And I'm still a newbee with Git/github.

Congratulations guys, you're plugin is great !

I'm Éric Rogé, and I use csDoctrineActAsSortablePlugin on my website http://symfony-check.org

I've discover a small bug in csDoctrineActAsSortablePlugin when you use it with the SQLite DBMS.

When you want to use the ->moveToPosition() method on a foo object, here's the kind of request sent to database engine :

UPDATE foo_table SET position = position + 1 WHERE (position < 6 AND position >= 5) ORDER BY position DESC

The issue is that SQLite doesn't support the "order by" clause on update operations.
SQLite isn’t my main DBMS on the project, but it can be a really usefull tool for the unit test suite.

For me, "order by" is totally useless here. Even if the "position" column has a unique index.

As long as the records are correctly selected and the update operation is done in a single request, DBMS are smart enought to deal with it without any collision problem (successfully tested on Mysql 5, PostgreSQL 8 and PostgreSQL 9).

You should just remove the "order by" clause from the update operation.

Regard,

Éric Rogé
UI Studio
eric.roge@ui-studio.fr
http://ui-studio.fr
http://symfony-check.org
