### PR TITLE
Duplicate Index check fails when modifying a `uniqueBy` column 

### DIFF
--- a/lib/listener/Sortable.php
+++ b/lib/listener/Sortable.php
@@ -48,6 +48,30 @@ class Doctrine_Template_Listener_Sortable extends Doctrine_Record_Listener
   }
 
   /**
+   * When a sortable object is updated, check to see if any of the uniqueBy
+   * fields are modified before saving to prevent two items having the same
+   * position.
+   *
+   * @param string $Doctrine_Event
+   * @return void
+   */
+  public function preUpdate(Doctrine_Event $event) {
+    $fieldName = $this->_options['name'];
+    $object = $event->getInvoker();
+    $modified = $object->getModified();
+
+    //-- Check to see if any of the uniqueBy fields have been modified
+    foreach ($this->_options['uniqueBy'] as $field)
+    {
+      if ( array_key_exists($field, $modified) ) {
+        //-- Move it to the end
+        $object->$fieldName = $object->getFinalPosition()+1;
+        break;
+      }
+    }
+  }
+
+  /**
    * When a sortable object is deleted, promote all objects positioned lower than itself
    *
    * @param string $Doctrine_Event

--- a/test/unit/SortableUniqueByTest.php
+++ b/test/unit/SortableUniqueByTest.php
@@ -64,6 +64,18 @@ $t->info('Test Removing an item - items after it should be promoted');
     $t->is($a3['position'], 1, '"Third item" has been promoted to "1" from "2"');
     $t->is($a5['position'], 2, '"Fifth item" has been promoted to "2" from "3"');
     
+$t->info('Test Moving an item to a different category with an item already at the same rank');
+    
+    try {
+      $a1->Category = $categories[1];
+      $a1->save();
+    } catch (Doctrine_Connection_Sqlite_Exception $e) {
+      $t->info('WARNING: Doctrine_Connection_Sqlite_Exception caught.');
+    }
+    doctrine_refresh($a1);
+    $t->is($a1['category_id'], $categories[1]['id'], sprintf('"First item" has been moved to %s', $a3['Category']['name']));
+    $t->is($a1['position'], 3, '"First item" has been moved to "3" from "1"');
+
 $t->info('Test deleting a collection of sortable items');
     
     $d1 = new SortableArticleUniqueBy();


### PR DESCRIPTION
Steps to reproduce:
1. Create a Sortable Class with at least one uniqueBy column (we'll use `cat_id` in this example).
2. Create 3 objects with a `cat_id` of 1.  They should have positions 1, 2, and 3.
3. Create 1 objects with a `cat_id` of 2.  It should have a position of 1.
4. Try and move the most recent object from `cat_id` 2 to `cat_id` 1.
5. Observe the `Doctrine_Connection_Sqlite_Exception` thrown.

This Pull Request simply adds a few extra test cases and a preUpdate listener that will move an object to the end of the list if it is changing categories.

This seems to address the same issue as https://github.com/bshaffer/csDoctrineActAsSortablePlugin/pull/11, but with out the side effects.
