### PR TITLE
Update lib/template/Sortable.php line 108

### DIFF
--- a/lib/template/Sortable.php
+++ b/lib/template/Sortable.php
@@ -105,7 +105,7 @@ class Doctrine_Template_Sortable extends Doctrine_Template
     $object = $this->getInvoker();
     $position = $object->get($this->_options['name']);
 
-    if ($position < $object->getFinalPosition())
+    if ($position < $this->getFinalPosition())
     {
       $position = $this->getNextPosition();
 


### PR DESCRIPTION
The function 'getFinalPosition()' needs to be called on the Doctrine_Template_Sortable object since this class has the magical function. Else you would get an error saying the function does not exist on the $object which would require implementation of the method and that's not desirable since it's a behavior and should work out of the box.
