### PR TITLE
Bugfix in listener refreshPosition()

### DIFF
--- a/lib/listener/Sortable.php
+++ b/lib/listener/Sortable.php
@@ -91,9 +91,10 @@ class Doctrine_Template_Listener_Sortable extends Doctrine_Record_Listener
    */
   private function refreshPosition(Doctrine_Record $object)
   {
+      $fieldName = $this->_options['name'];
       $identifiers = $object->getTable()->getIdentifierColumnNames();
 
-      $query = $object->getTable()->createQuery()->select($this->_options['name']);
+      $query = $object->getTable()->createQuery()->select($fieldName);
 
       foreach($identifiers as $identifier)
       {
@@ -101,7 +102,7 @@ class Doctrine_Template_Listener_Sortable extends Doctrine_Record_Listener
       }
 
       $position = $query->fetchOne(array(), Doctrine::HYDRATE_ARRAY);
-      $object->set($this->_options['name'], $position['position'], false);
+      $object->set($fieldName, $position[$fieldName], false);
   }
 
   /**


### PR DESCRIPTION
Replacing hardcoded 'position' field with $this->_options['name'] so that refreshPosition works with names other than the default of position.
