### PR TITLE
Use the fieldname from the options

### DIFF
--- a/lib/listener/Sortable.php
+++ b/lib/listener/Sortable.php
@@ -121,7 +121,7 @@ class Doctrine_Template_Listener_Sortable extends Doctrine_Record_Listener
     // Quick fix forSoftDelete behavior
     if ($object->getTable()->hasTemplate('SoftDelete'))
     { 
-        $object->setPosition(null); 
+        $object->set($fieldName, null); 
         $object->save(); 
     } 
 


### PR DESCRIPTION
Currently this code is broken if someone has changed the default field name from "position" to something else. It should be using the fieldname from the options.
