### PR TITLE
Fix final position query on uniqueBy object

### DIFF
--- a/lib/template/Sortable.php
+++ b/lib/template/Sortable.php
@@ -482,7 +482,7 @@ class Doctrine_Template_Sortable extends Doctrine_Template
      {
        $q->addWhere($field . ' = ?', $object[$field]['id']);
      }
-     if (is_null($object[$field])) 
+     elseif (is_null($object[$field]))
      {
        $q->addWhere($field . ' IS NULL');
      }


### PR DESCRIPTION
On object uniqueBy, we ended up with a double where, the one for object and the other one given by else block.
